### PR TITLE
fix: escape pipe in enum member value table cell

### DIFF
--- a/src/processor/utils.ts
+++ b/src/processor/utils.ts
@@ -275,9 +275,9 @@ export function buildEnumContent(
       const memberEnum = m as ApiEnumMember
       const memberDeclared = m as ApiDeclaredItem
       builder.pushline(
-        `| ${memberEnum.displayName} | ${
+        `| ${memberEnum.displayName} | ${escapeTextForTable(
           memberEnum.initializerExcerpt.text
-        } | ${
+        )} | ${
           memberDeclared.tsdocComment &&
           memberDeclared.tsdocComment.summarySection
             ? getDocSectionContent(

--- a/test/__snapshots__/generator.test.ts.snap
+++ b/test/__snapshots__/generator.test.ts.snap
@@ -451,8 +451,8 @@ export declare enum TokenChars
 
 | Member | Value| Description |
 | --- | --- | --- |
-| Modulo | \\"%\\" | Modulo charactor |
-| Plus | \\"+\\" | Plus charactor |
+| Modulo | &quot;%&quot; | Modulo charactor |
+| Plus | &quot;+&quot; | Plus charactor |
 
 ### Remarks
 
@@ -1051,8 +1051,8 @@ export declare enum TokenChars
 
 | Member | Value| Description |
 | --- | --- | --- |
-| Modulo | \\"%\\" | Modulo charactor |
-| Plus | \\"+\\" | Plus charactor |
+| Modulo | &quot;%&quot; | Modulo charactor |
+| Plus | &quot;+&quot; | Plus charactor |
 
 ### Remarks
 
@@ -1651,8 +1651,8 @@ export declare enum TokenChars
 
 | Member | Value| Description |
 | --- | --- | --- |
-| Modulo | \\"%\\" | Modulo charactor |
-| Plus | \\"+\\" | Plus charactor |
+| Modulo | &quot;%&quot; | Modulo charactor |
+| Plus | &quot;+&quot; | Plus charactor |
 
 ### Remarks
 

--- a/test/__snapshots__/mutli.test.ts.snap
+++ b/test/__snapshots__/mutli.test.ts.snap
@@ -136,8 +136,8 @@ export declare enum TokenChars
 
 | Member | Value| Description |
 | --- | --- | --- |
-| Modulo | \\"%\\" | Modulo charactor |
-| Plus | \\"+\\" | Plus charactor |
+| Modulo | &quot;%&quot; | Modulo charactor |
+| Plus | &quot;+&quot; | Plus charactor |
 
 ### Remarks
 
@@ -499,8 +499,8 @@ export declare enum TokenChars
 
 | Member | Value| Description |
 | --- | --- | --- |
-| Modulo | \\"%\\" | Modulo charactor |
-| Plus | \\"+\\" | Plus charactor |
+| Modulo | &quot;%&quot; | Modulo charactor |
+| Plus | &quot;+&quot; | Plus charactor |
 
 ### Remarks
 

--- a/test/__snapshots__/toc.test.ts.snap
+++ b/test/__snapshots__/toc.test.ts.snap
@@ -463,8 +463,8 @@ export declare enum TokenChars
 
 | Member | Value| Description |
 | --- | --- | --- |
-| Modulo | \\"%\\" | Modulo charactor |
-| Plus | \\"+\\" | Plus charactor |
+| Modulo | &quot;%&quot; | Modulo charactor |
+| Plus | &quot;+&quot; | Plus charactor |
 
 #### Remarks
 

--- a/test/enum-pipe.test.ts
+++ b/test/enum-pipe.test.ts
@@ -1,0 +1,35 @@
+import path from 'path'
+import { ApiModel, ApiItemKind, ApiEnum } from '@microsoft/api-extractor-model'
+import { createContentBuilder } from '../src/builder'
+import { buildEnumContent } from '../src/processor/utils'
+import { GenerateStyle } from '../src/config'
+
+test('enum member initializer containing a pipe is escaped for the table cell', () => {
+  const model = new ApiModel()
+  const pkg = model.loadPackage(
+    path.resolve(__dirname, './fixtures/enum-pipe.api.json')
+  )
+  const apiEnum = pkg.members[0].members.find(
+    m => m.kind === ApiItemKind.Enum
+  ) as ApiEnum
+
+  const builder = createContentBuilder()
+  buildEnumContent(
+    GenerateStyle.Prefix,
+    model,
+    pkg,
+    () => '',
+    builder,
+    apiEnum,
+    []
+  )
+
+  const content = builder.content
+  // The `ReadWrite = Read | Write` initializer must keep its pipe escaped, the
+  // same way the Parameters "Type" column escapes its excerpt, so the row keeps
+  // three cells and the description is not pushed out of the table.
+  expect(content).toContain(
+    '| ReadWrite | Read &#124; Write | Combined read and write access |'
+  )
+  expect(content).not.toContain('| ReadWrite | Read | Write |')
+})

--- a/test/fixtures/enum-pipe.api.json
+++ b/test/fixtures/enum-pipe.api.json
@@ -1,0 +1,253 @@
+{
+ "metadata": {
+  "toolPackage": "@microsoft/api-extractor",
+  "toolVersion": "7.15.2",
+  "schemaVersion": 1004,
+  "oldestForwardsCompatibleVersion": 1001,
+  "tsdocConfig": {
+   "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+   "noStandardTags": true,
+   "tagDefinitions": [
+    {
+     "tagName": "@alpha",
+     "syntaxKind": "modifier"
+    },
+    {
+     "tagName": "@beta",
+     "syntaxKind": "modifier"
+    },
+    {
+     "tagName": "@defaultValue",
+     "syntaxKind": "block"
+    },
+    {
+     "tagName": "@decorator",
+     "syntaxKind": "block",
+     "allowMultiple": true
+    },
+    {
+     "tagName": "@deprecated",
+     "syntaxKind": "block"
+    },
+    {
+     "tagName": "@eventProperty",
+     "syntaxKind": "modifier"
+    },
+    {
+     "tagName": "@example",
+     "syntaxKind": "block",
+     "allowMultiple": true
+    },
+    {
+     "tagName": "@experimental",
+     "syntaxKind": "modifier"
+    },
+    {
+     "tagName": "@inheritDoc",
+     "syntaxKind": "inline"
+    },
+    {
+     "tagName": "@internal",
+     "syntaxKind": "modifier"
+    },
+    {
+     "tagName": "@label",
+     "syntaxKind": "inline"
+    },
+    {
+     "tagName": "@link",
+     "syntaxKind": "inline",
+     "allowMultiple": true
+    },
+    {
+     "tagName": "@override",
+     "syntaxKind": "modifier"
+    },
+    {
+     "tagName": "@packageDocumentation",
+     "syntaxKind": "modifier"
+    },
+    {
+     "tagName": "@param",
+     "syntaxKind": "block",
+     "allowMultiple": true
+    },
+    {
+     "tagName": "@privateRemarks",
+     "syntaxKind": "block"
+    },
+    {
+     "tagName": "@public",
+     "syntaxKind": "modifier"
+    },
+    {
+     "tagName": "@readonly",
+     "syntaxKind": "modifier"
+    },
+    {
+     "tagName": "@remarks",
+     "syntaxKind": "block"
+    },
+    {
+     "tagName": "@returns",
+     "syntaxKind": "block"
+    },
+    {
+     "tagName": "@sealed",
+     "syntaxKind": "modifier"
+    },
+    {
+     "tagName": "@see",
+     "syntaxKind": "block"
+    },
+    {
+     "tagName": "@throws",
+     "syntaxKind": "block",
+     "allowMultiple": true
+    },
+    {
+     "tagName": "@typeParam",
+     "syntaxKind": "block",
+     "allowMultiple": true
+    },
+    {
+     "tagName": "@virtual",
+     "syntaxKind": "modifier"
+    },
+    {
+     "tagName": "@betaDocumentation",
+     "syntaxKind": "modifier"
+    },
+    {
+     "tagName": "@internalRemarks",
+     "syntaxKind": "block"
+    },
+    {
+     "tagName": "@preapproved",
+     "syntaxKind": "modifier"
+    }
+   ],
+   "supportForTags": {
+    "@alpha": true,
+    "@beta": true,
+    "@defaultValue": true,
+    "@decorator": true,
+    "@deprecated": true,
+    "@eventProperty": true,
+    "@example": true,
+    "@experimental": true,
+    "@inheritDoc": true,
+    "@internal": true,
+    "@label": true,
+    "@link": true,
+    "@override": true,
+    "@packageDocumentation": true,
+    "@param": true,
+    "@privateRemarks": true,
+    "@public": true,
+    "@readonly": true,
+    "@remarks": true,
+    "@returns": true,
+    "@sealed": true,
+    "@see": true,
+    "@throws": true,
+    "@typeParam": true,
+    "@virtual": true,
+    "@betaDocumentation": true,
+    "@internalRemarks": true,
+    "@preapproved": true
+   }
+  }
+ },
+ "kind": "Package",
+ "canonicalReference": "flags!",
+ "docComment": "",
+ "name": "flags",
+ "members": [
+  {
+   "kind": "EntryPoint",
+   "canonicalReference": "flags!",
+   "name": "",
+   "members": [
+    {
+     "kind": "Enum",
+     "canonicalReference": "flags!FileAccess:enum",
+     "docComment": "/**\n * File access flags.\n */\n",
+     "excerptTokens": [
+      {
+       "kind": "Content",
+       "text": "export declare enum FileAccess "
+      }
+     ],
+     "releaseTag": "Public",
+     "name": "FileAccess",
+     "members": [
+      {
+       "kind": "EnumMember",
+       "canonicalReference": "flags!FileAccess.Read:member",
+       "docComment": "/**\n * Read permission\n */\n",
+       "excerptTokens": [
+        {
+         "kind": "Content",
+         "text": "Read = "
+        },
+        {
+         "kind": "Content",
+         "text": "1 << 1"
+        }
+       ],
+       "releaseTag": "Public",
+       "name": "Read",
+       "initializerTokenRange": {
+        "startIndex": 1,
+        "endIndex": 2
+       }
+      },
+      {
+       "kind": "EnumMember",
+       "canonicalReference": "flags!FileAccess.Write:member",
+       "docComment": "/**\n * Write permission\n */\n",
+       "excerptTokens": [
+        {
+         "kind": "Content",
+         "text": "Write = "
+        },
+        {
+         "kind": "Content",
+         "text": "1 << 2"
+        }
+       ],
+       "releaseTag": "Public",
+       "name": "Write",
+       "initializerTokenRange": {
+        "startIndex": 1,
+        "endIndex": 2
+       }
+      },
+      {
+       "kind": "EnumMember",
+       "canonicalReference": "flags!FileAccess.ReadWrite:member",
+       "docComment": "/**\n * Combined read and write access\n */\n",
+       "excerptTokens": [
+        {
+         "kind": "Content",
+         "text": "ReadWrite = "
+        },
+        {
+         "kind": "Content",
+         "text": "Read | Write"
+        }
+       ],
+       "releaseTag": "Public",
+       "name": "ReadWrite",
+       "initializerTokenRange": {
+        "startIndex": 1,
+        "endIndex": 2
+       }
+      }
+     ]
+    }
+   ]
+  }
+ ]
+}


### PR DESCRIPTION
## What

The `Members` table generated for an enum prints each member's initializer
value straight from `initializerExcerpt.text` without escaping it:

```
| ${memberEnum.displayName} | ${
  memberEnum.initializerExcerpt.text
} | ${ ... } |
```

When the initializer contains a pipe, that raw `|` adds an extra column to the
row. For a flags enum such as:

```ts
enum FileAccess {
  Read = 1 << 1,
  Write = 1 << 2,
  ReadWrite = Read | Write,
}
```

the `ReadWrite` row becomes `| ReadWrite | Read | Write | ... |`, which has four
cells against a three-column header. GitHub-Flavored Markdown then splits the
value (`Read` / `Write`) and pushes the Description out of the row, so the
table loses data.

## Fix

The parameters table already escapes its excerpt before putting it in a cell.
The `Type` column runs `p.parameterTypeExcerpt.text` through
`escapeTextForTable` for exactly this reason (union types contain pipes too).
This change routes the enum value column through the same helper so both
columns escape consistently. `escapeTextForTable` maps `|` to `&#124;`, which
renders as a literal pipe and keeps the row at three cells.

## Tests

- Added `test/enum-pipe.test.ts` with a fixture whose member initializer is
  `Read | Write`, asserting the value stays in one cell and the description
  survives.
- Updated the existing enum snapshots: the value column now escapes the same
  way the `Type` column already does, so `"%"` becomes `&quot;%&quot;` (the
  same treatment as `DumbType&lt;T&gt;`).

`npm run lint` and the unit tests pass.
